### PR TITLE
Tag '2.0.0' does not exist, Tag '2.0' is the correct one

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ I made them as classes and you can use it with ease.
 **Swift 3 / Swift 4** 
 
 ``` ruby
-pod 'TKSubmitTransition', :git => 'https://github.com/entotsu/TKSubmitTransition.git', :tag => '2.0.0'
+pod 'TKSubmitTransition', :git => 'https://github.com/entotsu/TKSubmitTransition.git', :tag => '2.0'
 ```
 
 


### PR DESCRIPTION
`Pod install` does not find commit with tag '2.0.0', but rather works with the tag '2.0'.